### PR TITLE
Исправление тестов и бага с whereis

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Repairs are executed consecutively. If there is any error, the program stops and
 
 If `go 1.17+` is installed locally, then `make build` will create an executable in `output/scylla-octopus`. 
 
-We can also build a docker image:
+Building docker image:
 
 ```
 make docker-image

--- a/app/backup/metadata_test.go
+++ b/app/backup/metadata_test.go
@@ -2,9 +2,9 @@ package backup
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"github.com/kolesa-team/scylla-octopus/pkg/cmd/test"
 	"github.com/kolesa-team/scylla-octopus/pkg/entity"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"testing"
 	"time"
@@ -26,6 +26,13 @@ func TestService_writeMetadata(t *testing.T) {
 			Commit:  "abcdef",
 			Date:    "2021-10-22",
 		},
+		Archive: entity.Archive{
+			Method:         "pigz",
+			ArchiveOptions: entity.ArchiveOptions{
+				Compression: "1",
+				Threads:     "2",
+			},
+		},
 	}
 
 	err := service.writeMetadata(context.Background(), &cmdExecutor, "test-host", metadata)
@@ -45,6 +52,11 @@ buildInfo:
     version: 1.0.0
     commit: abcdef
     date: "2021-10-22"
+archive:
+    method: pigz
+    options:
+        compression: "1"
+        threads: "2"
 `,
 		string(cmdExecutor.WrittenFileBytes),
 	)


### PR DESCRIPTION
После предыдущего пр по архивации сломались тесты Test_BinaryExists и TestService_writeMetadata.
Это прошло незамеченным, потому что автоматический запуск тестов у нас не настроен. Пока нужно помнить о запуске `make test` перед пушем вручную.