### PR TITLE
правки по имени кластера и дата-центра

### DIFF
--- a/app/backup/service.go
+++ b/app/backup/service.go
@@ -246,14 +246,16 @@ func (s *Service) localBackupExists(ctx context.Context, cmdExecutor cmd.Executo
 
 // Uploads the local directory to a remote storage.
 // Creates the following directory hierarchy:
-//├── cluster_name
-//│   ├── node_1_short_domain_name
-//│   │   ├── date(dd-mm-yyy-hh-mm)
-//│   │   │   ├── db_schema.cql
-//│   │   │   ├── data
-//│   │   │   │   ├── keyspaces
-//│   │   │   │   │   ├── tables
-//│   ├── node_2_short_domain_name...
+// -- cluster_name
+//    -- datacenter_name
+//      -- node_1_short_domain_name
+//        -- date(dd-mm-yyy-hh-mm)
+//          -- metadata.yml
+//          -- db_schema.cql
+//          -- data
+//            -- keyspaces
+//            -- tables
+//      -- node_2_short_domain_name...
 func (s *Service) upload(ctx context.Context, node *entity.Node, remotePath string) error {
 	logCtx := s.logger.With("host", node.Info.Host, "remotePath", remotePath)
 	logCtx.Infow("uploading backup", "remotePath", remotePath)

--- a/config/local.yml
+++ b/config/local.yml
@@ -7,6 +7,8 @@ credentials:
 
 cluster:
   dataPath: /var/lib/scylla/data
+  # by default, clusterName is taken from `nodetool describecluster`
+  # clusterName: my-cluster
   binaries:
     cqlsh: /usr/bin/cqlsh
     nodetool: /usr/bin/nodetool

--- a/config/remote.yml
+++ b/config/remote.yml
@@ -6,12 +6,14 @@ credentials:
 
 cluster:
   hosts:
-    # ip addresses from remote.yml.
+    # ip addresses from docker-compose.yml.
     # can also accept domain names (except this doesn't work with docker-compose).
     - 10.5.0.2
     - 10.5.0.3
     - 10.5.0.4
   dataPath: /var/lib/scylla/data
+  # by default, clusterName is taken from `nodetool describecluster`
+  # clusterName: my-cluster
   binaries:
     cqlsh: /usr/bin/cqlsh
     nodetool: /usr/bin/nodetool

--- a/pkg/awscli/client.go
+++ b/pkg/awscli/client.go
@@ -3,9 +3,9 @@ package awscli
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"github.com/kolesa-team/scylla-octopus/pkg/cmd"
 	"github.com/kolesa-team/scylla-octopus/pkg/entity"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"os/exec"
 	"strings"
@@ -67,16 +67,18 @@ func (c *Client) Upload(ctx context.Context, cmdExecutor cmd.Executor, source, d
 // ListBackups returns backups from a given directory
 func (c *Client) ListBackups(ctx context.Context, cmdExecutor cmd.Executor, basePath string) ([]entity.RemoteBackup, error) {
 	backups := []entity.RemoteBackup{}
-	// TODO the backups are kept at a 2nd leven of hierarchy, e.g. /basePath/scylla-node1/09-07-2021-10-29
+	// TODO the backups are kept at a 3rd leven of hierarchy, e.g. /basePath/datacenter/scylla-node1/09-07-2021-10-29
 	// this probably should not be hardcoded
-	paths, err := c.listDirectoriesRecursive(ctx, cmdExecutor, basePath, 2)
+	paths, err := c.listDirectoriesRecursive(ctx, cmdExecutor, basePath, 3)
 	if err != nil {
 		c.logger.Errorw(
 			"could not list backups",
 			"error", err,
 		)
 
-		return backups, err
+		// the error most probably means there are no files at given path,
+		// so we allow ourselves ignore it.
+		return backups, nil
 	}
 
 	for _, path := range paths {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -21,9 +21,11 @@ type Cluster struct {
 
 type Options struct {
 	// a list of hosts where the tool should run
-	Hosts    []string
-	Binaries entity.NodeBinaries
-	DataPath string `yaml:"dataPath"`
+	Hosts          []string
+	Binaries       entity.NodeBinaries
+	DataPath       string `yaml:"dataPath"`
+	ClusterName    string `yaml:"clusterName"`
+	SkipDnsResolve bool
 }
 
 // A factory interface that creates shell-command executors.
@@ -59,8 +61,13 @@ func NewCluster(
 				host,
 				opts.DataPath,
 				opts.Binaries,
-				true,
+				// resolve domain names except when running tests
+				opts.SkipDnsResolve == false,
 			),
+		}
+
+		if len(opts.ClusterName) > 0 {
+			node.Info.ClusterName = opts.ClusterName
 		}
 
 		cluster.nodes[host] = &node

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -3,10 +3,10 @@ package cluster
 import (
 	"context"
 	"errors"
-	"github.com/stretchr/testify/require"
 	"github.com/kolesa-team/scylla-octopus/pkg/cmd"
 	"github.com/kolesa-team/scylla-octopus/pkg/cmd/local"
 	"github.com/kolesa-team/scylla-octopus/pkg/entity"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"testing"
 	"time"
@@ -24,7 +24,8 @@ func (l localCmdFactory) GetByHost(host string) (cmd.Executor, error) {
 func TestCluster_RunParallel_Ok(t *testing.T) {
 	cluster := NewCluster(
 		Options{
-			Hosts: []string{"host-1", "host-2"},
+			Hosts:          []string{"host-1", "host-2"},
+			SkipDnsResolve: true,
 		},
 		localCmdFactory{},
 		zap.S(),
@@ -57,7 +58,8 @@ func TestCluster_RunParallel_Ok(t *testing.T) {
 func TestCluster_RunParallel_WithContextTimeout(t *testing.T) {
 	cluster := NewCluster(
 		Options{
-			Hosts: []string{"host-1", "host-2"},
+			Hosts:          []string{"host-1", "host-2"},
+			SkipDnsResolve: true,
 		},
 		localCmdFactory{},
 		zap.S(),
@@ -99,7 +101,8 @@ func TestCluster_RunParallel_WithContextTimeout(t *testing.T) {
 func TestCluster_RunParallel_WithError(t *testing.T) {
 	cluster := NewCluster(
 		Options{
-			Hosts: []string{"host-1", "host-2"},
+			Hosts:          []string{"host-1", "host-2"},
+			SkipDnsResolve: true,
 		},
 		localCmdFactory{},
 		zap.S(),
@@ -141,7 +144,8 @@ func TestCluster_RunParallel_WithError(t *testing.T) {
 func TestCluster_Run_Ok(t *testing.T) {
 	cluster := NewCluster(
 		Options{
-			Hosts: []string{"host-1", "host-2"},
+			Hosts:          []string{"host-1", "host-2"},
+			SkipDnsResolve: true,
 		},
 		localCmdFactory{},
 		zap.S(),
@@ -175,7 +179,8 @@ func TestCluster_Run_Ok(t *testing.T) {
 func TestCluster_Run_WithError(t *testing.T) {
 	cluster := NewCluster(
 		Options{
-			Hosts: []string{"host-1", "host-2"},
+			Hosts:          []string{"host-1", "host-2"},
+			SkipDnsResolve: true,
 		},
 		localCmdFactory{},
 		zap.S(),

--- a/pkg/entity/node.go
+++ b/pkg/entity/node.go
@@ -20,6 +20,7 @@ type NodeInfo struct {
 	DomainName  string
 	DataPath    string
 	ClusterName string
+	Datacenter  string
 	// a status according to `nodetool status`
 	Status   string
 	Binaries NodeBinaries
@@ -87,11 +88,12 @@ func (n NodeInfo) IsStatusOk() bool {
 }
 
 // RemoteStoragePath returns a path where the backup from a node should be stored in s3.
-// The format is "cluster-name/short-domain-name"
+// The format is "cluster-name/datacenter/domain-name"
 func (n NodeInfo) RemoteStoragePath() string {
 	return fmt.Sprintf(
-		"%s/%s",
+		"%s/%s/%s",
 		n.ClusterName,
+		n.Datacenter,
 		n.ShortDomainName(),
 	)
 }

--- a/pkg/scylla/node_test.go
+++ b/pkg/scylla/node_test.go
@@ -2,9 +2,9 @@ package scylla
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"github.com/kolesa-team/scylla-octopus/pkg/cmd/test"
 	"github.com/kolesa-team/scylla-octopus/pkg/entity"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"testing"
 )
@@ -27,7 +27,7 @@ DN  172.20.0.3  205.89 KB  256          ?       ba29ac08-b405-4d26-8a8b-2b8c18c9
 		credentials: entity.Credentials{},
 		logger:      zap.S(),
 	}
-	status, err := client.getNodeStatus(context.Background(), entity.NewNode(
+	status, dc, err := client.getNodeStatus(context.Background(), entity.NewNode(
 		entity.NodeInfo{
 			IpAddress: "172.20.0.2",
 		},
@@ -35,7 +35,8 @@ DN  172.20.0.3  205.89 KB  256          ?       ba29ac08-b405-4d26-8a8b-2b8c18c9
 		nil,
 	))
 	require.NoError(t, err)
-	require.Equal(t, status, entity.NodeStatusOk)
+	require.Equal(t, entity.NodeStatusOk, status)
+	require.Equal(t, "DC1", dc)
 }
 
 func TestClient_NodeStatus_Error(t *testing.T) {
@@ -55,7 +56,7 @@ UN  172.20.0.3  205.89 KB  256          ?       ba29ac08-b405-4d26-8a8b-2b8c18c9
 		credentials: entity.Credentials{},
 		logger:      zap.S(),
 	}
-	status, err := client.getNodeStatus(context.Background(), entity.NewNode(
+	status, dc, err := client.getNodeStatus(context.Background(), entity.NewNode(
 		entity.NodeInfo{
 			IpAddress: "172.20.0.2",
 		},
@@ -63,7 +64,8 @@ UN  172.20.0.3  205.89 KB  256          ?       ba29ac08-b405-4d26-8a8b-2b8c18c9
 		nil,
 	))
 	require.NoError(t, err)
-	require.Equal(t, status, "DN", "статус узла должен быть равен DN (down, normal)")
+	require.Equal(t, "DC1", dc)
+	require.Equal(t, "DN", status, "node status must be DN (down, normal)")
 }
 
 func TestClient_ClusterName_Ok(t *testing.T) {


### PR DESCRIPTION
По запросу Алибека, теперь
* можно принудительно задать в конфиге имя кластера (если не указано, то берём его как и раньше из nodetool status)
* путь к бэкапу включает в себя название дата-центра (его берём из nodetool describecluster)